### PR TITLE
Stop LuaControllers from overheating (fixes #1)

### DIFF
--- a/minetest/misc.lua
+++ b/minetest/misc.lua
@@ -33,14 +33,13 @@ local function get_gametime_init(dtime)
 	end
 	for index, globalstep in pairs(minetest.registered_globalsteps) do
 		if globalstep == get_gametime_init then
-			table.remove(minetest.registered_globalsteps, index)
+			-- globalsteps of mods which depend on modlib will execute after this
+			minetest.registered_globalsteps[index] = function(dtime)
+				gametime = gametime + dtime
+			end
 			break
 		end
 	end
-	-- globalsteps of mods which depend on modlib will execute after this
-	minetest.register_globalstep(function(dtime)
-		gametime = gametime + dtime
-	end)
 end
 minetest.register_globalstep(get_gametime_init)
 


### PR DESCRIPTION
This fixes #1.

## What I think is happening

 - Mesecons runs [`actionqueue.lua`](https://github.com/minetest-mods/mesecons/blob/e15c55c0667f62f971cc58b7d3fb5f771ea4a68d/mesecons/actionqueue.lua#L116-L131), registers a globalstep to cool down mesecons devices, and saves its index for later.
 - Mesecons then runs `services.lua` and registers a globalstep that handles the cooling down of mesecons nodes.
 - Modlib's globalstep runs after the server has initialised, deletes itself, and registers a new globalstep, breaking the old order of the globalstep functions.
 - After 4 seconds, `actionqueue.lua` replaces the globalstep at the previously saved index with a different function. Normally, this would replace its own globalstep, however it instead replaces the next globalstep registered since the indexes are now offset, which is the globalstep registered in `services.lua`.
 - LuaControllers and other mesecons devices can no longer cool down and will overheat very easily.

## How this is fixed

Modlib now replaces the globalstep it adds rather than removing it and adding a new one. This preserves the order of all other globalstep functions.