### PR TITLE
Close the file after reading

### DIFF
--- a/file.lua
+++ b/file.lua
@@ -127,6 +127,7 @@ function process_bridge_listen(name, line_consumer, step)
 			line_consumer(line)
 			line = content:read()
 		end
+		content:close()
 		write(bridge.input, "")
 	end)
 end


### PR DESCRIPTION
the file must be closed otherwise on Unix systems it creates an overflow