### PR TITLE
Remove reference to non-existent debug.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,6 @@ for _, file in pairs{
 	"bluon",
 	"base64",
 	"persistence",
-	"debug",
 	"web",
 	"tex"
 } do


### PR DESCRIPTION
Note that I have not actually tested this PR but it seems simple enough